### PR TITLE
Use id instead of hash on code object

### DIFF
--- a/depyf/decompiler.py
+++ b/depyf/decompiler.py
@@ -1169,7 +1169,7 @@ class Decompiler:
                 f"Failed to decompile {self.code.co_name}") from e
 
     def __hash__(self):
-        return hash(self.code)
+        return id(self.code)
 
 
 def decompile(code: Union[CodeType, Callable]):

--- a/depyf/decompiler.py
+++ b/depyf/decompiler.py
@@ -1169,6 +1169,7 @@ class Decompiler:
                 f"Failed to decompile {self.code.co_name}") from e
 
     def __hash__(self):
+        # see https://github.com/thuml/depyf/pull/21
         return id(self.code)
 
 


### PR DESCRIPTION
Hashing `code` objects should not be done; `code` objects are not always hashable.
`code` objects are not hashable if `co_consts` includes non-hashable types (dict, set, list, etc).
Including non-hashable types in `co_consts` is valid.
I ran into this bug while trying to use depyf with torch dynamo on a model.
To reproduce:

```
import types
code_dict = {
	'co_argcount': 0,
	'co_posonlyargcount': 0,
	'co_kwonlyargcount': 0,
	'co_nlocals': 0,
	'co_stacksize': 1,
	'co_flags': 0,
	'co_code': b'd\x00S\x00',
	'co_consts': ({'a': 'b'},), # this could be a dict or set or any unhashable type
	'co_names': (),
	'co_varnames': (),
	'co_filename': 'fake.py',
	'co_name': 'fake',
	'co_firstlineno': 123,
	'co_linetable': b'',
	'co_freevars': (),
	'co_cellvars': ()
}

code_obj = types.CodeType(*[code_dict[k] for k in code_dict])

print('code returns:', types.FunctionType(code_obj, globals())())

import dis
dis.dis(code_obj)

try:
	hash(code_obj)
except TypeError as e:
	print("can't hash code:", e)

import depyf
print(depyf.decompile(code_obj))
```

Output:
```
code returns: {'a': 'b'}
          0 LOAD_CONST               0 ({'a': 'b'})
          2 RETURN_VALUE
can't hash code: unhashable type: 'dict'
Traceback (most recent call last):
  File "/.../bug.py", line 34, in <module>
    print(depyf.decompile(code_obj))
  File "/.../lib/python3.10/site-packages/depyf/decompiler.py", line 1171, in decompile
    return Decompiler(code).decompile()
  File "/.../lib/python3.10/site-packages/depyf/decompiler.py", line 1166, in __hash__
    return hash(self.code)
TypeError: unhashable type: 'dict'
```