### PR TITLE
Add __eq__ method to fix cache

### DIFF
--- a/depyf/decompiler.py
+++ b/depyf/decompiler.py
@@ -1172,6 +1172,8 @@ class Decompiler:
         # see https://github.com/thuml/depyf/pull/21
         return id(self.code)
 
+    def __eq__(self, other):
+        return hash(self) == hash(other)
 
 def decompile(code: Union[CodeType, Callable]):
     """Decompile a code object or a function."""


### PR DESCRIPTION
Implementing `__hash__` is not enough, `lru_cache` is still not caching the calls. Added `__eq__` implementation to fix.

To reproduce:
```
import depyf

def f():
    print('hello')

code = f.__code__

depyf.Decompiler(code).decompile()
depyf.Decompiler(code).decompile()
print(depyf.Decompiler.decompile.cache_info())
```
Output:
```
CacheInfo(hits=0, misses=2, maxsize=None, currsize=2)
```