### PR TITLE
Add missing default argument values in `patched_load_by_key_path`

### DIFF
--- a/depyf/explain/patched_load_by_key_path.py
+++ b/depyf/explain/patched_load_by_key_path.py
@@ -1,8 +1,8 @@
 def patched_load_by_key_path(
     key: str,
     path: str,
-    linemap,
-    attrs,
+    linemap=None,
+    attrs=None,
 ):
     from depyf.explain.global_variables import data
     from depyf.explain.utils import write_code_to_file_template, get_current_compiled_fn_name


### PR DESCRIPTION
This PR fixes #80  by aligning the default argument values of `patched_load_by_key_path` with the unpatched `load_by_key_path` function (see https://github.com/pytorch/pytorch/blob/v2.6.0/torch/_inductor/codecache.py#L2753--L2754).