### PR TITLE
Add device to imports

### DIFF
--- a/depyf/explain/patched_lazy_format_graph_code.py
+++ b/depyf/explain/patched_lazy_format_graph_code.py
@@ -27,7 +27,7 @@ def patched_lazy_format_graph_code(name, gm, maybe_id=None, **kwargs):
     use_gm = True
 
     # use `print_readable` because it can include submodules
-    src = "from __future__ import annotations\nimport torch\n" + \
+    src = "from __future__ import annotations\nimport torch\nfrom torch import device\n" + \
         gm.print_readable(print_output=False)
     src = src.replace("<lambda>", "GraphModule")
     try:


### PR DESCRIPTION
This PR imports `torch.device` to further reduce the lint errors