### PR TITLE
Use python 3.14 compatible counter value retrieval in get_current_compiled_fn_name

### DIFF
--- a/depyf/explain/utils.py
+++ b/depyf/explain/utils.py
@@ -334,5 +334,5 @@ def get_current_compiled_fn_name():
     from copy import copy
     # torch.compile already called the next, we should add minus 1 to get the
     # correct name
-    current_count = next(copy(_unique_id_counter)) - 1
+    current_count = int(str(_unique_id_counter).replace("count(","").replace(")","")) - 1
     return "__compiled_fn_" + str(current_count)


### PR DESCRIPTION
Using `copy(itertools.count())` results in a 

`TypeError: cannot pickle 'itertools.count' object`

error in Python 3.14.

This PR makes it so that this operation is compatible with Python 3.14.  The result of the evaluation is the same, even though
it doesn't look as nice.

```
>>> import itertools
>>> from copy import copy
>>> c = itertools.count()
>>> next(copy(c)) - 1
-1
>>> int(str(c).replace("count(","").replace(")","")) - 1
-1
>>>
```
